### PR TITLE
sepolicy: Import LiveDisplay rules

### DIFF
--- a/common/private/genfs_contexts
+++ b/common/private/genfs_contexts
@@ -2,3 +2,13 @@ genfscon fuseblk / u:object_r:vfat:s0
 genfscon sdfat / u:object_r:exfat:s0
 
 genfscon sysfs /devices/virtual/timed_output/vibrator u:object_r:sysfs_vibrator:s0
+
+# LiveDisplay
+genfscon sysfs /devices/virtual/graphics/fb0/acl u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/aco u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/cabc u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/color_enhance u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/hbm u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/rgb u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/sre u:object_r:sysfs_livedisplay_tuneable:s0
+genfscon sysfs /devices/virtual/graphics/fb0/reading_mode u:object_r:sysfs_livedisplay_tuneable:s0

--- a/common/private/hwservice_contexts
+++ b/common/private/hwservice_contexts
@@ -1,0 +1,10 @@
+# LiveDisplay
+vendor.lineage.livedisplay::IAdaptiveBacklight       u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IAutoContrast            u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IColorBalance            u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IColorEnhancement        u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IDisplayColorCalibration u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IDisplayModes            u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IPictureAdjustment       u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::IReadingEnhancement      u:object_r:hal_lineage_livedisplay_hwservice:s0
+vendor.lineage.livedisplay::ISunlightEnhancement     u:object_r:hal_lineage_livedisplay_hwservice:s0

--- a/common/private/init.te
+++ b/common/private/init.te
@@ -2,3 +2,6 @@ allow init sysfs_dm:dir relabelfrom;
 allow init sysfs_dm:file relabelfrom;
 
 allow init sysfs_io_sched_tuneable:file { setattr w_file_perms };
+
+# LiveDisplay
+allow init sysfs_livedisplay_tuneable:file { setattr w_file_perms };

--- a/common/private/platform_app.te
+++ b/common/private/platform_app.te
@@ -1,2 +1,5 @@
 # Allow NFC service to be found
 allow platform_app nfc_service:service_manager find;
+
+# Allow LiveDisplay HAL service to be found
+hal_client_domain(platform_app, hal_lineage_livedisplay)

--- a/common/private/service_contexts
+++ b/common/private/service_contexts
@@ -1,1 +1,5 @@
 edgegestureservice                        u:object_r:edgegesture_service:s0
+
+# LiveDisplay
+lineagehardware                           u:object_r:lineage_hardware_service:s0
+lineagelivedisplay                        u:object_r:lineage_livedisplay_service:s0

--- a/common/private/system_app.te
+++ b/common/private/system_app.te
@@ -1,2 +1,5 @@
 # Allow Settings to read ro.vendor.build.security_patch
 get_prop(system_app, vendor_security_patch_level_prop)
+
+# LiveDisplay
+hal_client_domain(system_app, hal_lineage_livedisplay)

--- a/common/private/system_server.te
+++ b/common/private/system_server.te
@@ -2,3 +2,9 @@ allow system_server storage_stub_file:dir getattr;
 set_prop(system_server, shell_prop)
 
 allow system_server edgegesture_service:service_manager { add find };
+
+# Allow LineageHW (running as system server) to access LiveDisplay tuneables
+allow system_server sysfs_livedisplay_tuneable:file rw_file_perms;
+
+# Use HALs
+hal_client_domain(system_server, hal_lineage_livedisplay)

--- a/common/public/attributes
+++ b/common/public/attributes
@@ -1,0 +1,2 @@
+# LiveDisplay
+hal_attribute(lineage_livedisplay)

--- a/common/public/file.te
+++ b/common/public/file.te
@@ -1,0 +1,1 @@
+type sysfs_livedisplay_tuneable, fs_type, sysfs_type;

--- a/common/public/hal_lineage_livedisplay.te
+++ b/common/public/hal_lineage_livedisplay.te
@@ -1,0 +1,8 @@
+# HwBinder IPC from client to server
+binder_call(hal_lineage_livedisplay_client, hal_lineage_livedisplay_server)
+
+add_hwservice(hal_lineage_livedisplay_server, hal_lineage_livedisplay_hwservice)
+allow hal_lineage_livedisplay_client hal_lineage_livedisplay_hwservice:hwservice_manager find;
+
+# Grant access over LiveDisplay tuneables
+allow hal_lineage_livedisplay_server sysfs_livedisplay_tuneable:file rw_file_perms;

--- a/common/public/hwservice.te
+++ b/common/public/hwservice.te
@@ -1,0 +1,1 @@
+type hal_lineage_livedisplay_hwservice, hwservice_manager_type;

--- a/common/public/service.te
+++ b/common/public/service.te
@@ -1,0 +1,3 @@
+# LiveDisplay
+type lineage_hardware_service, system_api_service, system_server_service, service_manager_type;
+type lineage_livedisplay_service, system_api_service, system_server_service, service_manager_type;

--- a/common/vendor/file_contexts
+++ b/common/vendor/file_contexts
@@ -9,3 +9,8 @@
 
 # Vibrator HAL
 /(vendor|system/vendor)/bin/hw/android\.hardware\.vibrator@1\.0-service\.aosip u:object_r:hal_vibrator_default_exec:s0
+
+# LiveDisplay HAL
+/(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.0-service-legacymm u:object_r:hal_lineage_livedisplay_default_exec:s0
+/(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.0-service-sdm u:object_r:hal_lineage_livedisplay_default_exec:s0
+/(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.0-service-sysfs u:object_r:hal_lineage_livedisplay_default_exec:s0

--- a/common/vendor/hal_lineage_livedisplay_default.te
+++ b/common/vendor/hal_lineage_livedisplay_default.te
@@ -1,0 +1,8 @@
+type hal_lineage_livedisplay_default, domain;
+hal_server_domain(hal_lineage_livedisplay_default, hal_lineage_livedisplay)
+
+type hal_lineage_livedisplay_default_exec, exec_type, vendor_file_type, file_type;
+init_daemon_domain(hal_lineage_livedisplay_default)
+
+# Allow LiveDisplay HAL's default implementation to use vendor-binder service
+vndbinder_use(hal_lineage_livedisplay_default)

--- a/qcom/common/hal_lineage_livedisplay_default.te
+++ b/qcom/common/hal_lineage_livedisplay_default.te
@@ -1,0 +1,14 @@
+# Do not use add_service() as hal_graphics_composer_default may be the provider as well
+allow hal_lineage_livedisplay_default qdisplay_service:service_manager find;
+
+binder_call(hal_lineage_livedisplay_default, hal_graphics_composer_default)
+
+# Allow LiveDisplay to store files under /data/vendor/display and access them
+allow hal_lineage_livedisplay_default display_vendor_data_file:dir rw_dir_perms;
+allow hal_lineage_livedisplay_default display_vendor_data_file:file create_file_perms;
+
+# Allow LiveDisplay to access vendor display property
+get_prop(hal_lineage_livedisplay_default, vendor_display_prop)
+
+# Allow LiveDisplay to access pps socket
+unix_socket_connect(hal_lineage_livedisplay_default, pps, mm-pp-daemon)


### PR DESCRIPTION
Squashed of:

commit 78fce70bc81f120229fabf7573f0a5afee73bcbe
Author: dianlujitao <dianlujitao@lineageos.org>
Date:   Thu Feb 14 20:08:40 2019 +0800

    common: Mark platform_app as hal_lineage_livedisplay client

     * Don't explicitly depend on hal_lineage_livedisplay_hwservice

    Change-Id: I9a6c8ee0ccd8478d379b14893cd451da9a4bf336

commit a21eabfc07fd85ee752ff91935612b75839af037
Author: Paul Keith <javelinanddart@gmail.com>
Date:   Thu Feb 7 11:54:48 2019 -0600

    common: Label livedisplay 2.0 sysfs service

    * Add label for acl node too for devices that use it

    Change-Id: Iaa69ad07f122a6a74182afe7db49d4c21bd88842

commit 701b30de766a77ce1831ef1385a28babfe397161
Author: Bruno Martins <bgcngm@gmail.com>
Date:   Mon Jan 21 10:10:45 2019 +0000

    common: Migrate to livedisplay 2.0

    Change-Id: Ib67bf7fb29b202c031a2ad3556596a8b91fd5d54

commit 87d305d76a91d5eea5e884a9aa2b554d6f974271
Author: Bruno Martins <bgcngm@gmail.com>
Date:   Thu Jan 31 16:09:49 2019 +0000

    lineage: Properly write rules for Lineage LiveDisplay as a HAL

     * This is how Google defines rules for a new HAL, split between
       private (for platform-only types, permissions, and attributes),
       public (for types and attributes) and finally vendor.

    Change-Id: I94a299f03bd413afd76ae02a2d979f37eb444709

commit aaad39fbdfebcdc8c25eccc90b52be5059b95fe1
Author: dianlujitao <dianlujitao@lineageos.org>
Date:   Wed Jan 9 13:18:19 2019 +0800

    Allow LiveDisplay to access vendor display property

    Change-Id: I7ddf94b5846d97d0eba82b728ef59e3924cc6235

commit dd4ff844957ee5a3f5b8e643cb9d2610f85d6e9b
Author: Bruno Martins <bgcngm@gmail.com>
Date:   Sat Nov 24 22:27:33 2018 +0000

    common: Label and allow access over LiveDisplay sysfs nodes

    Change-Id: I57bddaa04ed071b8ab9dcde3d8cdc206c81e3662

commit 953c9ca4e7f279a0fd1baa1b2b20d41c54bf5ed2
Author: Ethan Chen <intervigil@gmail.com>
Date:   Thu May 3 23:19:03 2018 -0700

    sepolicy: Add legacy-mm livedisplay label

    Change-Id: I56f59362b58878749fd772bd75cdc6e7bd74ccac

commit 5ebc0dc6921573400552707f48a7c939fae1e7a5
Author: Bruno Martins <bgcngm@gmail.com>
Date:   Sat Feb 24 19:35:07 2018 +0000

    sepolicy: Add rules for LiveDisplay HIDL HAL

     * The HIDL HAL replaces the JNI implementation, so remove the old rules.

    Change-Id: I9b83480633041122c5093d35f31d2ecc1f61149a

commit dbf3187ee0c6e59fee74d3a8eb40f0625e28a3c2
Author: Sam Mortimer <sam@mortimer.me.uk>
Date:   Thu Oct 5 20:54:33 2017 -0700

    lineage sepolicy: add lineage-sdk services

Change-Id: I81d0ac1769a63d665140f92fc88a2e8228e0605a